### PR TITLE
fix: update employee entry and exit validation logic for accuracy

### DIFF
--- a/backend/dist/services/RecordService.js
+++ b/backend/dist/services/RecordService.js
@@ -2,19 +2,9 @@ import Record, { RecordType } from '../models/Record.js';
 import { selectedTimestampFormat } from '../utils/selectedTimestampFormat.js';
 export async function registerEntry(employeeId, selectedDate) {
     const selectedTimestamp = selectedTimestampFormat(selectedDate);
-    const lastEntry = await Record.findOne({
-        employeeId,
-        type: RecordType.ENTRY,
-    }).sort({ actualTimestamp: -1 });
-    if (lastEntry) {
-        const exitAfterwards = await Record.findOne({
-            employeeId,
-            type: RecordType.EXIT,
-            selectedTimestamp: { $gt: lastEntry.selectedTimestamp }
-        });
-        if (!exitAfterwards) {
-            throw new Error('El empleado ya está dentro de la compañía.');
-        }
+    const lastRecord = await Record.findOne({ employeeId }).sort({ actualTimestamp: -1 });
+    if (lastRecord?.type === RecordType.ENTRY) {
+        throw new Error('El empleado ya está dentro de la compañía.');
     }
     const newEntry = await Record.create({
         employeeId,

--- a/backend/src/services/EmployeeService.ts
+++ b/backend/src/services/EmployeeService.ts
@@ -5,25 +5,20 @@ export async function getEmployeesInside() {
   const now = new Date();
 
   const lastEntries = await Record.aggregate([
-    { $match: { type: RecordType.ENTRY } },
+    { $match: { selectedTimestamp: { $lte: now } }},
     { $sort: { selectedTimestamp: -1 } },
     {
       $group: {
         _id: '$employeeId',
-        selectedTimestamp: { $first: '$selectedTimestamp' }
+        type: { $first: '$type' },
+        selectedTimestamp: { $first: '$selectedTimestamp' },
       }
     }
   ]);
-
   const inside = [];
   for (const rec of lastEntries) {
-    const exit = await Record.findOne({
-      employeeId: rec._id,
-      type: RecordType.EXIT,
-      selectedTimestamp: { $gte: rec.selectedTimestamp, $lte: now }
-    }).sort({ selectedTimestamp: -1 });
-
-    if (!exit) inside.push(rec);
+    if (rec.type === RecordType.ENTRY)
+      inside.push(rec);
   }
 
   const ids = inside.map(r => r._id);

--- a/backend/src/services/RecordService.ts
+++ b/backend/src/services/RecordService.ts
@@ -3,21 +3,11 @@ import { selectedTimestampFormat } from '../utils/selectedTimestampFormat.js';
 
 export async function registerEntry(employeeId: string, selectedDate?: Date) {
   const selectedTimestamp = selectedTimestampFormat(selectedDate);
-  const lastEntry = await Record.findOne({
-    employeeId,
-    type: RecordType.ENTRY,
-  }).sort({ actualTimestamp: -1 });
-  
-  if (lastEntry) {
-    const exitAfterwards = await Record.findOne({
-      employeeId,
-      type: RecordType.EXIT,
-      selectedTimestamp: { $gt: lastEntry.selectedTimestamp }
-    });
-    
-    if (!exitAfterwards) {
-      throw new Error('El empleado ya está dentro de la compañía.');
-    } 
+
+  const lastRecord = await Record.findOne({ employeeId }).sort({ actualTimestamp: -1 });
+
+  if (lastRecord?.type === RecordType.ENTRY) {
+    throw new Error('El empleado ya está dentro de la compañía.');
   }
 
   const newEntry = await Record.create({
@@ -30,7 +20,7 @@ export async function registerEntry(employeeId: string, selectedDate?: Date) {
   return newEntry;
 }
 
-export async function registerExit(employeeId: string, selectedDate?: Date) {
+export async function registerExit(employeeId: string, selectedDate?: Date,) {
   const selectedTimestamp = selectedTimestampFormat(selectedDate);
   const entryPending = await Record.findOne({
     employeeId,


### PR DESCRIPTION
- change validation logic for the `getEmployeesInside` function so instead of searching for the last entry and exit only searches for the last record and if it is an `ENTRY` considers its inside the company.
- replicate the same logic for the `registerEntry` and `registerExit` 
- in the `getEmployeesInside` adds a validation so the employee would only appear on the company if the entry hour is before the actual hour.